### PR TITLE
force dark theme so light mode doesnt break

### DIFF
--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -9,7 +9,8 @@ export function Providers({ children }: { children: ReactNode }) {
   const router = useRouter()
 
   return (
-    <ThemeProvider attribute="class">
+    // force dark, light mode breaks it
+    <ThemeProvider attribute="class" forcedTheme="dark">
       <HeroUIProvider navigate={router.push}>{children}</HeroUIProvider>
     </ThemeProvider>
   )


### PR DESCRIPTION
the site is dark only (bg is hardcoded black in `page.tsx`) but it still follows the os theme. so on light mode the os breaks the layout

fix: force dark with `forcedTheme="dark"`. dark users see no changes but light users dont see broken layout

repro: set macos to light, open the site

<img width="400" alt="light mode broken layout" src="https://github.com/user-attachments/assets/e75b6bda-cd80-4e2f-9453-68905ee29ef9" />
